### PR TITLE
tomcat version update, deploy to ROOT context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,20 +29,20 @@ RUN set -ex \
 	done
 
 ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.8
+ENV TOMCAT_VERSION 8.5.11
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
-
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
 	&& curl -fSL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
+    && rm -rf webapps/* \
 	&& rm tomcat.tar.gz*
 
 # tadpole resource
 RUN wget 'https://sourceforge.net/projects/tadpoledbhub/files/1.7.x/1.7.3/tadpole.war'
-RUN mv $CATALINA_HOME/tadpole.war $CATALINA_HOME/webapps/
+RUN mv $CATALINA_HOME/tadpole.war $CATALINA_HOME/webapps/ROOT.war
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Docker tag
 
 Tadpole DB Hub start
 -
-* http://{tomcat ip}:{tomcat port}/tadpole/tadpole/
-
-* You must put the last /.(마지막 / 를 꼭 넣으셔야 합니다.)
+* http://{tomcat ip}:{tomcat port}
 
 Download
 -


### PR DESCRIPTION
context path를 굳이 명시하지않고 http://localhost:${tomcatport}/ 로 바로 접근가능한게 좀더 편하지 않을까 하는생각에 pull request를 보내드립니다 ^^; 

작업한 부분은 아래와 같습니다. 

- tomcat version update (8.5.8 -> 8.5.11)
- webapps 디렉토리에 필요없는 doc, examples, manager context 를 제거
- 올챙이가 ROOT context로 배포되도록 처리
- README.md 수정